### PR TITLE
Fix for links containing "prev" records

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -59,7 +59,7 @@ func (e *httpError) Error() string {
 }
 
 // linkRE provides parsing of the "Link" HTTP header directive.
-var linkRE = regexp.MustCompile(`^<(.*)>; rel="next", <(.*)>; rel="last".*`)
+var linkRE = regexp.MustCompile(`^.*<(.*)>; rel="next", <(.*)>; rel="last".*`)
 
 // fetchURL fetches the specified URL. The cache (specified in
 // c.CacheDir) is consulted first and if not found, the specified URL


### PR DESCRIPTION
Hi
Let say you are scanning repo with more than 60 stargazers
In this case Link header will look like

https://api.github.com/repositories/62678265/stargazers?page=1; rel="prev", https://api.github.com/repositories/62678265/stargazers?page=3; rel="next", https://api.github.com/repositories/62678265/stargazers?page=24; rel="last", https://api.github.com/repositories/62678265/stargazers?page=1; rel="first"

current regex will resolve it as https://api.github.com/repositories/62678265/stargazers?page=1>; rel="prev", <https://api.github.com/repositories/62678265/stargazers?page=3

expected:
https://api.github.com/repositories/62678265/stargazers?page=3

PR contains regex fix opened instead of #7 